### PR TITLE
Add docs for scheduled invocation

### DIFF
--- a/old/rpc.mdx
+++ b/old/rpc.mdx
@@ -17,7 +17,7 @@ Golem instead introduces a new way to do worker-to-worker communication, using a
 The low-level host interface this technique uses is defined in [wasm-rpc.wit](https://github.com/golemcloud/golem-wit/blob/main/wit/deps/wasm-rpc/wasm-rpc.wit) as the following:
 
 ```rust
-package golem:rpc@0.1.0;
+package golem:rpc@0.1.2;
 
 interface types {
   use wasi:io/poll@0.2.0.{pollable};
@@ -71,6 +71,8 @@ interface types {
     invoke: func(function-name: string, function-params: list<wit-value>) -> result<_, rpc-error>;
 
     async-invoke-and-await: func(function-name: string, function-params: list<wit-value>) -> future-invoke-result;
+
+    schedule-invocation: func(scheduled-time: datetime, function-name: string, function-params: list<wit-value>) -> ();
   }
 }
 

--- a/old/rpc.mdx
+++ b/old/rpc.mdx
@@ -17,7 +17,7 @@ Golem instead introduces a new way to do worker-to-worker communication, using a
 The low-level host interface this technique uses is defined in [wasm-rpc.wit](https://github.com/golemcloud/golem-wit/blob/main/wit/deps/wasm-rpc/wasm-rpc.wit) as the following:
 
 ```rust
-package golem:rpc@0.1.2;
+package golem:rpc@0.1.0;
 
 interface types {
   use wasi:io/poll@0.2.0.{pollable};
@@ -71,8 +71,6 @@ interface types {
     invoke: func(function-name: string, function-params: list<wit-value>) -> result<_, rpc-error>;
 
     async-invoke-and-await: func(function-name: string, function-params: list<wit-value>) -> future-invoke-result;
-
-    schedule-invocation: func(scheduled-time: datetime, function-name: string, function-params: list<wit-value>) -> ();
   }
 }
 

--- a/src/pages/docs/_meta.json
+++ b/src/pages/docs/_meta.json
@@ -45,5 +45,6 @@
   "rib": "Rib",
   "golem-host-functions": "Golem Host Functions",
   "function-names": "Function names",
-  "json-wave-mapping": "JSON-WAVE Mapping"
+  "json-wave-mapping": "JSON-WAVE Mapping",
+  "wasm-rpc": "WASM RPC"
 }

--- a/src/pages/docs/concepts/worker-to-worker-communication.mdx
+++ b/src/pages/docs/concepts/worker-to-worker-communication.mdx
@@ -32,3 +32,87 @@ systems, Golem provides a feature called _worker-to-worker communication_. This
 feature allows you to simply, and in a type-safe way, communicate between
 workers, with strong guarantees, such as reliable, exactly-once invocation
 semantics.
+
+# WASM-RPC
+
+<Callout type="warning">
+  Prefer the typed approaches to worker-invocation defined above. This section describes the
+  underlying interfaces that are used by golem itself to implement the typed approaches to RPC.
+</Callout>
+
+The low-level interface to invoke other workers from within a component is the [WASM-RPC](https://github.com/golemcloud/golem-wit/blob/main/wit/deps/wasm-rpc/wasm-rpc.wit) wit package.
+The basic workflow of using this package is to construct an instance of the `wasm-rpc` resource (which represents a remote component worker) and call the appropriate method on it.
+
+## Constructing an instance
+
+The only argument required to construct an wasm-rpc resource is the URI of the worker you wish to invoke. The structure of this URI is `urn:worker:{component_id}/{worker_name}`.
+Both `component_id` and `worker_name` are given to you by golem when you create a component and worker respectively.
+
+## WIT-Value
+
+As the wasm-rpc package is not statically typed, it is required to be able to pass as arguments and return arbitrary WIT values. This is done using the WIT-Value datatype which is a reified
+version of the regular WIT types. There is one constructor of the related WIT-Node type for each type in the WIT typesystem, i.e. a `list<u64>` with value `[1, 2, 4]` might be represented like this in a rust component using wasm-rpc:
+
+```rust
+WitValue {
+      nodes: vec![WitNode::ListValue(vec![1, 2, 3]), WitNode::PrimU64(1), WitNode::PrimU64(2), WitNode::PrimU64(4)]
+}
+```
+
+<Callout type="info">
+  The value that will end up becoming the root of the resulting WIT Value needs to be placed in
+  index 0 of the nodes array!
+</Callout>
+
+All functions in the wasm-rpc package use wit-value instead of the equivalent wit type. Invoking a function with incorrect wit-values with lead to an error.
+
+## Invocation
+
+After you have constructed an instance of wasm-rpc there are a number of different functions you can choose from, depending on the invocation semantics you need.
+
+- invoke: Non-blockingly call the desired function. Errors during invocation are returned, but the actual result of the invocation cannot be accessed.
+- invoke-and-await: Blockingly call the desired function. The result of the invocation will be returned to you.
+- async-invoke-and-await: Non-blockingly call the desired function. A resource will be returned to you that you can use to poll the result.
+- schedule-invocation: Schedule an invocation for a point in time in the future.
+- schedule-cancelable-invocation: Schedule an invocation for a point in time in the future. A resource will be returned to you that you can cancel the invocation as long as it hasn't been executed yet.
+
+## Example
+
+Given the following WIT world implemented by a component:
+
+```wit
+package golem:example;
+
+interface invocation-example-api {
+  add: func(value: u64);
+}
+
+world invocation-example {
+  export invocation-example-api;
+}
+```
+
+A rust component could use the wasm-rpc package to schedule an invocation of 'add' 2 seconds in the future like this:
+
+```rust
+let uri = Uri { value: format!("urn:worker:{}/{}", component_id, worker_name) }
+
+let wasi_rpc = WasmRpc::new(&uri);
+
+let now = OffsetDateTime::now_utc();
+
+let scheduled_time = now.saturating_add(Duration::seconds(2));
+
+let scheduled_wasi_time = WasiDatetime {
+   seconds: scheduled_time.unix_timestamp() as u64,
+   nanoseconds: scheduled_time.nanosecond()
+};
+
+let value: WitValue = {
+   use self::bindings::golem::rpc::types::*;
+   WitValue {
+         nodes: vec![WitNode::PrimU64(1)]
+   }
+};
+wasi_rpc.schedule_invocation(scheduled_wasi_time, "golem:example/invocation-example-api.{add}()", &vec![value]);
+```

--- a/src/pages/docs/concepts/worker-to-worker-communication.mdx
+++ b/src/pages/docs/concepts/worker-to-worker-communication.mdx
@@ -33,86 +33,10 @@ feature allows you to simply, and in a type-safe way, communicate between
 workers, with strong guarantees, such as reliable, exactly-once invocation
 semantics.
 
-# WASM-RPC
+# Learn More
 
-<Callout type="warning">
-  Prefer the typed approaches to worker-invocation defined above. This section describes the
-  underlying interfaces that are used by golem itself to implement the typed approaches to RPC.
-</Callout>
-
-The low-level interface to invoke other workers from within a component is the [WASM-RPC](https://github.com/golemcloud/golem-wit/blob/main/wit/deps/wasm-rpc/wasm-rpc.wit) wit package.
-The basic workflow of using this package is to construct an instance of the `wasm-rpc` resource (which represents a remote component worker) and call the appropriate method on it.
-
-## Constructing an instance
-
-The only argument required to construct an wasm-rpc resource is the URI of the worker you wish to invoke. The structure of this URI is `urn:worker:{component_id}/{worker_name}`.
-Both `component_id` and `worker_name` are given to you by golem when you create a component and worker respectively.
-
-## WIT-Value
-
-As the wasm-rpc package is not statically typed, it is required to be able to pass as arguments and return arbitrary WIT values. This is done using the WIT-Value datatype which is a reified
-version of the regular WIT types. There is one constructor of the related WIT-Node type for each type in the WIT typesystem, i.e. a `list<u64>` with value `[1, 2, 4]` might be represented like this in a rust component using wasm-rpc:
-
-```rust
-WitValue {
-      nodes: vec![WitNode::ListValue(vec![1, 2, 3]), WitNode::PrimU64(1), WitNode::PrimU64(2), WitNode::PrimU64(4)]
-}
-```
-
-<Callout type="info">
-  The value that will end up becoming the root of the resulting WIT Value needs to be placed in
-  index 0 of the nodes array!
-</Callout>
-
-All functions in the wasm-rpc package use wit-value instead of the equivalent wit type. Invoking a function with incorrect wit-values with lead to an error.
-
-## Invocation
-
-After you have constructed an instance of wasm-rpc there are a number of different functions you can choose from, depending on the invocation semantics you need.
-
-- invoke: Non-blockingly call the desired function. Errors during invocation are returned, but the actual result of the invocation cannot be accessed.
-- invoke-and-await: Blockingly call the desired function. The result of the invocation will be returned to you.
-- async-invoke-and-await: Non-blockingly call the desired function. A resource will be returned to you that you can use to poll the result.
-- schedule-invocation: Schedule an invocation for a point in time in the future.
-- schedule-cancelable-invocation: Schedule an invocation for a point in time in the future. A resource will be returned to you that you can cancel the invocation as long as it hasn't been executed yet.
-
-## Example
-
-Given the following WIT world implemented by a component:
-
-```wit
-package golem:example;
-
-interface invocation-example-api {
-  add: func(value: u64);
-}
-
-world invocation-example {
-  export invocation-example-api;
-}
-```
-
-A rust component could use the wasm-rpc package to schedule an invocation of 'add' 2 seconds in the future like this:
-
-```rust
-let uri = Uri { value: format!("urn:worker:{}/{}", component_id, worker_name) }
-
-let wasi_rpc = WasmRpc::new(&uri);
-
-let now = OffsetDateTime::now_utc();
-
-let scheduled_time = now.saturating_add(Duration::seconds(2));
-
-let scheduled_wasi_time = WasiDatetime {
-   seconds: scheduled_time.unix_timestamp() as u64,
-   nanoseconds: scheduled_time.nanosecond()
-};
-
-let value: WitValue = {
-   use self::bindings::golem::rpc::types::*;
-   WitValue {
-         nodes: vec![WitNode::PrimU64(1)]
-   }
-};
-wasi_rpc.schedule_invocation(scheduled_wasi_time, "golem:example/invocation-example-api.{add}()", &vec![value]);
-```
+- [Worker to Worker Communication in Rust](/docs/rust-language-guide/rpc)
+- [Worker to Worker Communication in C/C++](/docs/ccpp-language-guide/rpc)
+- [Worker to Worker Communication in Python](/docs/python-language-guide/rpc)
+- [Worker to Worker Communication in Go](/docs/go-language-guide/rpc)
+- [WASM-RPC](/docs/wasm-rpc)

--- a/src/pages/docs/golem-host-functions.mdx
+++ b/src/pages/docs/golem-host-functions.mdx
@@ -6,8 +6,8 @@ Golem provides two WIT **packages** of host functions for accessing Golem-specif
 
 These two packages are:
 
-- `golem:api@1.1.0` - provides access to various aspects of Golem for the workers
-- `golem:rpc@0.1.0` - defines the types and functions serving the [Worker to Worker communication](concepts/worker-to-worker-communication) in Golem
+- `golem:api@1.1.2` - provides access to various aspects of Golem for the workers
+- `golem:rpc@0.1.2` - defines the types and functions serving the [Worker to Worker communication](concepts/worker-to-worker-communication) in Golem
 
 Please check the **language specific guidelines** to learn the best way to work with these APIs in your language of choice:
 

--- a/src/pages/docs/golem-host-functions.mdx
+++ b/src/pages/docs/golem-host-functions.mdx
@@ -6,8 +6,8 @@ Golem provides two WIT **packages** of host functions for accessing Golem-specif
 
 These two packages are:
 
-- `golem:api@1.1.2` - provides access to various aspects of Golem for the workers
-- `golem:rpc@0.1.2` - defines the types and functions serving the [Worker to Worker communication](concepts/worker-to-worker-communication) in Golem
+- `golem:api@1.1.4` - provides access to various aspects of Golem for the workers
+- `golem:rpc@0.1.3` - defines the types and functions serving the [Worker to Worker communication](concepts/worker-to-worker-communication) in Golem
 
 Please check the **language specific guidelines** to learn the best way to work with these APIs in your language of choice:
 

--- a/src/pages/docs/wasm-rpc.mdx
+++ b/src/pages/docs/wasm-rpc.mdx
@@ -1,0 +1,86 @@
+import { Callout } from "nextra/components"
+
+# WASM-RPC
+
+<Callout type="warning">
+  Prefer the typed approaches to worker-invocation explained in the
+  [introduction](/docs/worker-to-worker-communication). This section describes the underlying
+  interfaces that are used by golem itself to implement the typed approaches to RPC.
+</Callout>
+
+The low-level interface to invoke other workers from within a component is the [WASM-RPC](https://github.com/golemcloud/golem-wit/blob/main/wit/deps/wasm-rpc/wasm-rpc.wit) wit package.
+The basic workflow of using this package is to construct an instance of the `wasm-rpc` resource (which represents a remote worker) and call the appropriate method on it.
+
+## Constructing an instance
+
+The only argument required to construct an wasm-rpc resource is the URI of the worker you wish to invoke. The structure of this URI is `urn:worker:{component_id}/{worker_name}`.
+Both `component_id` and `worker_name` are given to you by golem when you create a component and worker respectively.
+
+## WIT-Value
+
+As the wasm-rpc package is not statically typed, it is required to be able to pass as arguments and return arbitrary WIT values. This is done using the WIT-Value datatype which is a reified
+version of the regular WIT types. There is one constructor of the related WIT-Node type for each type in the WIT typesystem, i.e. a `list<u64>` with value `[1, 2, 4]` might be represented like this in a rust component using wasm-rpc:
+
+```rust
+WitValue {
+      nodes: vec![WitNode::ListValue(vec![1, 2, 3]), WitNode::PrimU64(1), WitNode::PrimU64(2), WitNode::PrimU64(4)]
+}
+```
+
+<Callout type="info">
+  The value that will end up becoming the root of the resulting WIT Value needs to be placed in
+  index 0 of the nodes array!
+</Callout>
+
+All functions in the wasm-rpc package use wit-value instead of the equivalent wit type. Invoking a function with incorrect wit-values with lead to an error.
+
+## Invocation
+
+After you have constructed an instance of wasm-rpc there are a number of different functions you can choose from, depending on the invocation semantics you need.
+
+- invoke: Non-blockingly call the desired function. Errors during invocation are returned, but the actual result of the invocation cannot be accessed.
+- invoke-and-await: Blockingly call the desired function. The result of the invocation will be returned to you.
+- async-invoke-and-await: Non-blockingly call the desired function. A resource will be returned to you that you can use to poll the result.
+- schedule-invocation: Schedule an invocation for a point in time in the future.
+- schedule-cancelable-invocation: Schedule an invocation for a point in time in the future. A resource will be returned to you that you can cancel the invocation as long as it hasn't been executed yet.
+
+## Example
+
+Given the following WIT world implemented by a component:
+
+```wit
+package golem:example;
+
+interface invocation-example-api {
+  add: func(value: u64);
+}
+
+world invocation-example {
+  export invocation-example-api;
+}
+```
+
+A rust component could use the wasm-rpc package to schedule an invocation of 'add' 2 seconds in the future like this:
+
+```rust
+let uri = Uri { value: format!("urn:worker:{}/{}", component_id, worker_name) }
+
+let wasi_rpc = WasmRpc::new(&uri);
+
+let now = OffsetDateTime::now_utc();
+
+let scheduled_time = now.saturating_add(Duration::seconds(2));
+
+let scheduled_wasi_time = WasiDatetime {
+   seconds: scheduled_time.unix_timestamp() as u64,
+   nanoseconds: scheduled_time.nanosecond()
+};
+
+let value: WitValue = {
+   use self::bindings::golem::rpc::types::*;
+   WitValue {
+         nodes: vec![WitNode::PrimU64(1)]
+   }
+};
+wasi_rpc.schedule_invocation(scheduled_wasi_time, "golem:example/invocation-example-api.{add}()", &vec![value]);
+```


### PR DESCRIPTION
resolves #109 

@vigoo We don't really document normal wasm-rpc invocation much, except showing the wit definition and explaining how to instantiate the rpc resource. I think that doing the same for the normal scheduled invocation is enough.

Once we generate proper stubs using the stubgen and there is some generated interface to use, I think it would make more sense to document that one properly with a dedicated section -- as it is the one that users normally use.