### PR TITLE
Update quickstart.mdx - make build stable

### DIFF
--- a/src/pages/docs/quickstart.mdx
+++ b/src/pages/docs/quickstart.mdx
@@ -44,7 +44,7 @@ Alternatively, you can build and install the universal version of `golem-cli`
 with the following command:
 
 ```bash filename="Terminal" copy
-cargo install --features universal golem-cloud-cli
+cargo install --locked --features universal golem-cloud-cli
 ```
 
 This command installs both universal `golem-cli` (with support for cloud and


### PR DESCRIPTION
Without using locked versions, sometimes developers have to deal with yanked dependencies.
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/185e7f21-6c86-4440-8a47-dcf2a048df6b" />
