### PR TITLE
Replace componentId with component.name and component.version

### DIFF
--- a/src/pages/invoke/making-custom-apis/authentication.mdx
+++ b/src/pages/invoke/making-custom-apis/authentication.mdx
@@ -56,8 +56,8 @@ routes:
   security: my-unique-security-scheme
   binding:
     type: wit-worker
-    componentId:
-      componentId: 0b6d9cd8-f373-4e29-8a5a-548e61b868a5
+    component:
+      name: "my-todo-api"
       version: 0
     response: |
       let email: string = request.auth.email;

--- a/src/pages/invoke/making-custom-apis/define-api-definition.mdx
+++ b/src/pages/invoke/making-custom-apis/define-api-definition.mdx
@@ -26,8 +26,8 @@ routes:
     path: /v4/{user-id}/get-cart-contents
     binding:
       type: default
-      componentId:
-        componentId: dba38841-013a-49fa-a1dc-064949832f0c
+      component:
+        name: "shopping-cart"
         version: 0
       response: |
         let user: u64 = request.path.user-id;
@@ -37,7 +37,7 @@ routes:
 ```
 
 Please use this as a reference instead of using it with zero changes. For example, you might need to give a different
-version, componentId etc (explained below). You can get the `component` details including `componentId`
+version, component etc (explained below). You can get the `component` details including `name` and `version`
 by running `golem component list` command.
 
 The API definition's fields have the following meaning:
@@ -58,7 +58,7 @@ Let's break down the binding object.
 | Field         | Description                                                                                                                                                                                                                                                                                                                                                                                      |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `type`        | Specifies the type of binding. Here, it is set to "default", indicating that the binding involves a Golem worker.                                                                                                                                                                                                                                                                             |
-| `componentId` | Provides the component ID associated with the worker binding. As you can see the the golem-worker                                                                                                                                                                                                                                                                                                |
+| `component`   | Specifies the component's name and version                                                                                                                                                                                                                                                                                          |
 | `response`    | The `response` field here is a Rib expression that allows you to call any worker function and manipulates its output.                                                                                                                                                                                                                                                                            |
 
 See the [binding type reference](/http-api-definitions/worker-binding-types) for more details on the supported binding types.

--- a/src/pages/invoke/making-custom-apis/import-openapi-spec.mdx
+++ b/src/pages/invoke/making-custom-apis/import-openapi-spec.mdx
@@ -74,8 +74,8 @@ This will return
       "method": "Get",
       "path": "/{user-id}/get-cart-contents",
       "binding": {
-        "componentId": {
-          "componentId": "dba38841-013a-49fa-a1dc-064949832f0c",
+        "component": {
+          "name": "my-shopping-cart",
           "version": 0
         },
         "idempotencyKey": null,

--- a/src/pages/invoke/making-custom-apis/spec-inference.mdx
+++ b/src/pages/invoke/making-custom-apis/spec-inference.mdx
@@ -15,8 +15,8 @@ Here is a sample response when you register an API definition, where it holds th
       "method": "Get",
       "path": "/v4/{user-id}/get-cart-contents",
       "binding": {
-        "componentId": {
-          "componentId": "dba38841-013a-49fa-a1dc-064949832f0c",
+        "component": {
+          "name": "shopping-cart",
           "version": 0
         },
         "workerName": "let user: u64 = request.path.user-id;\n\"my-worker-${user}\"",

--- a/src/pages/rest-api/cloud-rest-api/api-definition.mdx
+++ b/src/pages/rest-api/cloud-rest-api/api-definition.mdx
@@ -21,8 +21,8 @@ API definition using it.
       "path": "string",
       "security": "string",
       "binding": {
-        "componentId": {
-          "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+        "component": {
+          "name": "string",
           "version": 0
         },
         "workerName": "string",
@@ -149,8 +149,8 @@ Lists all API definitions associated with the project.
         "path": "string",
         "security": "string",
         "binding": {
-          "componentId": {
-            "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+          "component": {
+            "name": "string",
             "version": 0
           },
           "workerName": "string",
@@ -272,8 +272,8 @@ If an API definition of the same version already exists, its an error.
       "path": "string",
       "security": "string",
       "binding": {
-        "componentId": {
-          "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+        "component": {
+          "name": "string",
           "version": 0
         },
         "workerName": "string",
@@ -393,8 +393,8 @@ An API definition is selected by its API definition ID and version.
       "path": "string",
       "security": "string",
       "binding": {
-        "componentId": {
-          "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+        "component": {
+          "name": "string",
           "version": 0
         },
         "workerName": "string",
@@ -514,8 +514,8 @@ Only draft API definitions can be updated.
       "path": "string",
       "security": "string",
       "binding": {
-        "componentId": {
-          "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+        "component": {
+          "name": "string",
           "version": 0
         },
         "workerName": "string",

--- a/src/pages/rest-api/oss-rest-api/api-definition.mdx
+++ b/src/pages/rest-api/oss-rest-api/api-definition.mdx
@@ -24,8 +24,8 @@ API definition using it.
       "path": "string",
       "security": "string",
       "binding": {
-        "componentId": {
-          "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+        "component": {
+          "name": "string",
           "version": 0
         },
         "workerName": "string",
@@ -154,8 +154,8 @@ api-definition-id|string|No|-
         "path": "string",
         "security": "string",
         "binding": {
-          "componentId": {
-            "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+          "component": {
+            "name": "string",
             "version": 0
           },
           "workerName": "string",
@@ -280,8 +280,8 @@ If an API definition of the same version already exists, its an error.
       "path": "string",
       "security": "string",
       "binding": {
-        "componentId": {
-          "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+        "component": {
+          "name": "string",
           "version": 0
         },
         "workerName": "string",
@@ -404,8 +404,8 @@ An API definition is selected by its API definition ID and version.
       "path": "string",
       "security": "string",
       "binding": {
-        "componentId": {
-          "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+        "component": {
+          "name": "string",
           "version": 0
         },
         "workerName": "string",
@@ -528,8 +528,8 @@ Only draft API definitions can be updated.
       "path": "string",
       "security": "string",
       "binding": {
-        "componentId": {
-          "componentId": "616ccd92-d666-4180-8349-8d125b269fac",
+        "component": {
+          "name": "string",
           "version": 0
         },
         "workerName": "string",


### PR DESCRIPTION
Update the API definition to use the recent binding format by replacing `componentId` with `component` that includes `name` and `version`. This change enhances clarity and aligns with the new component structure.