### PR TITLE
Change command from 'golem account' to 'golem cloud account'

### DIFF
--- a/src/pages/cli/profiles.mdx
+++ b/src/pages/cli/profiles.mdx
@@ -68,7 +68,7 @@ To authenticate your Golem Cloud profile, you can run any command that requires 
 The easiest way to authenticate your profile would be to run the following command:
 
 ```bash copy
-golem account get
+golem cloud account get
 ```
 
 At the moment, the only way to authenticate your account is to use GitHub OAuth2 authorization. Please follow the instructions in your terminal and authorize the ZivergeTech organization to use OAuth2:


### PR DESCRIPTION
Updated command for authenticating Golem Cloud profile.