### PR TITLE
Modify authentication command for Golem Cloud

### DIFF
--- a/src/pages/cli/profiles.mdx
+++ b/src/pages/cli/profiles.mdx
@@ -68,7 +68,7 @@ To authenticate your Golem Cloud profile, you can run any command that requires 
 The easiest way to authenticate your profile would be to run the following command:
 
 ```bash copy
-golem cloud account get
+golem cloud account get --cloud
 ```
 
 At the moment, the only way to authenticate your account is to use GitHub OAuth2 authorization. Please follow the instructions in your terminal and authorize the ZivergeTech organization to use OAuth2:


### PR DESCRIPTION
Updated the command for authenticating Golem Cloud profile to include the '--cloud' option.

cc @vigoo 
To make the command line easier, the golem cli may need to be cleaned up! Switching to the `cloud` profile or using the `--cloud` option is unnecessary.